### PR TITLE
Will only apply --depth when fetchDepth is a positive value

### DIFF
--- a/buildandreleasetask/index.js
+++ b/buildandreleasetask/index.js
@@ -66,7 +66,11 @@ function run() {
         }
         const sourceBranch = convertRefToBranch(tl.getVariable('Build.SourceBranch') || '');
         executeCommand(`git version`);
-        var response = executeCommand(`git clone --filter=tree:0 --no-checkout --depth ${fetchDepth} --sparse --no-tags --progress --no-recurse-submodules https://${accessToken}@${repositoryUri} .`);
+        var cloneCommand = `git clone --filter=tree:0 --no-checkout --sparse --no-tags --progress --no-recurse-submodules https://${accessToken}@${repositoryUri} .`;
+        if (Number(fetchDepth) > 0) {
+            cloneCommand = `git clone --filter=tree:0 --no-checkout --depth ${fetchDepth} --sparse --no-tags --progress --no-recurse-submodules https://${accessToken}@${repositoryUri} .`;
+        }
+        var response = executeCommand(cloneCommand);
         if (response.includes('existing Git repository')) {
             tl.setResult(tl.TaskResult.Failed, 'Repository already exists. Set "checkout:none" in previous checkout task to avoid this error.');
             return;

--- a/buildandreleasetask/index.ts
+++ b/buildandreleasetask/index.ts
@@ -69,7 +69,11 @@ function run() {
         const sourceBranch = convertRefToBranch(tl.getVariable('Build.SourceBranch') || '');
 
         executeCommand(`git version`);
-        var response = executeCommand(`git clone --filter=tree:0 --no-checkout --depth ${fetchDepth} --sparse --no-tags --progress --no-recurse-submodules https://${accessToken}@${repositoryUri} .`);
+        let cloneCommand = `git clone --filter=tree:0 --no-checkout --sparse --no-tags --progress --no-recurse-submodules https://${accessToken}@${repositoryUri} .`;
+        if (Number(fetchDepth) > 0) {
+            cloneCommand = `git clone --filter=tree:0 --no-checkout --depth ${fetchDepth} --sparse --no-tags --progress --no-recurse-submodules https://${accessToken}@${repositoryUri} .`;
+        }
+        const response = executeCommand(cloneCommand);
         if (response.includes('existing Git repository')) {
             tl.setResult(tl.TaskResult.Failed, 'Repository already exists. Set "checkout:none" in previous checkout task to avoid this error.');
             return;


### PR DESCRIPTION
This is to fix when fetchDepth is set to "0". 

This will fix this error:

> ##[error]Command failed: git clone --filter=tree:0 --no-checkout --depth 0 --sparse --no-tags --progress --no-recurse-submodules [https://***](https://%2A%2A%2A/) .
fatal: depth 0 is not a positive number